### PR TITLE
:sparkles: Adds is_formatted output argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ inputs:
     required: false
     default: ""
 ```
-
 ### Docker input args
 
 Besides the aforementioned input arguments you can also supply additional input arguments for the black formatter using the args keyword [run.args](https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/metadata-syntax-for-github-actions#runsargs).
@@ -74,6 +73,14 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args: ". --verbose"
+```
+
+## Outputs
+
+```yml
+outputs:
+  is_formatted:
+    description: "Whether the files were formatted using the black formatter."
 ```
 
 ## Basic usage

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ jobs:
           level: warning
 ```
 
-## Advance use cases
+## Advanced use cases
 
 This action can be combined with [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) or [stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action) to also apply the annotated changes to the repository.
 

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,9 @@ inputs:
     description: "Additional reviewdog flags."
     required: false
     default: ""
+outputs:
+  is_formatted:
+    description: "Whether the files were formatted using the black formatter."
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,9 +58,18 @@ fi
 # NOTE: Useful for writing back changes or creating a pull request.
 if [[ "${INPUT_FORMAT}" = 'true' && "${black_error}" = 'true' ]]; then
   echo "[action-black] Formatting python code using the black formatter..."
-  black "${INPUT_WORKDIR}/${black_args}" || black_error="true"
+  black "${INPUT_WORKDIR}/${black_args}" || black_format_error="true"
+
+  # Check if code was formatted
+  if [[ "${black_format_error}" != "true" ]]; then
+    echo "::set-output name=is_formatted::true"
+  else
+    black_error="${black_format_error}"
+    echo "::set-output name=is_formatted::false"
+  fi
 elif [[ "${INPUT_FORMAT}" = 'true' && "${black_error}" != 'true' ]]; then
   echo "[action-black] Formatting not needed."
+  echo "::set-output name=is_formatted::false"
 fi
 
 # Throw error if an error occurred and fail_on_error is true


### PR DESCRIPTION
This pull request adds the `is_formatted` output argument. This argument can be usefull when combining this action with other actions.