### PR TITLE
[fixed] product version for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: reviewdog/action-black@v1
+      - uses: reviewdog/action-black@v2
         with:
           github_token: ${{ secrets.github_token }}
           # Change reviewdog reporter if you need [github-pr-check, github-check].


### PR DESCRIPTION
fixed product version for readme. v1 -> v2
It's a simple fix, but I want you to incorporate it. Because I didn't understand this and was in great trouble.

Specifically, the argument of black is different from the document and an error occurred.
(args -> black_args #24 )