### PR TITLE
Jupyter notebook support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,17 @@ jobs:
         run: |
           expected_files=(num_guess.py num_guess.ipynb subfolder/queen_problem.py subfolder/queen_problem.ipynb)
           checked_files=(${{ env.BLACK_CHECK_FILE_PATHS }})
+          # Check whether the expected files are checked
+          for file in ${expected_files[@]}; do
+            if ! [[ " ${checked_files[*]} " == *"${file}"* ]]; then
+              echo "Black forgot to check file ${file}!"
+              exit 1
+            fi
+          done
+
+          # Check whether black checks files that should not be checked
           for file in ${checked_files[@]}; do
-            if ! [[ " ${expected_files[*]} " == *"$file"* ]]; then
+            if ! [[ " ${expected_files[*]} " == *"${file}"* ]]; then
               echo "Unexpected file ${file} got checked!"
               exit 1
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,17 @@ jobs:
             echo "Changes detected!"
             exit 1
           fi
+      - name: Check black would format the expected files
+        run: |
+          expected_files=(num_guess.py num_guess.ipynb subfolder/queen_problem.py subfolder/queen_problem.ipynb)
+          checked_files=(${{ env.BLACK_CHECK_FILE_PATHS }})
+          for file in ${checked_files[@]}; do
+            if ! [[ " ${expected_files[*]} " == *"$file"* ]]; then
+              echo "Unexpected file ${file} got checked!"
+              exit 1
+            fi
+          done
+          echo "Black checked the expected files: [${expected_files[@]}] successfully!"
 
   test-pr-check:
     if: github.event_name == 'pull_request'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ if [[ "${INPUT_REPORTER}" = 'github-pr-review' ]]; then
   black_check_output="$(black --diff --quiet --check . ${INPUT_BLACK_ARGS})" ||
     black_exit_val="$?"
 
-  # Intput black formatter output to reviewdog
+  # Input black formatter output to reviewdog
   # shellcheck disable=SC2086
   echo "${black_check_output}" | /tmp/reviewdog -f="diff" \
     -f.diff.strip=0 \
@@ -46,7 +46,7 @@ else
   black_check_output="$(black --check . ${INPUT_BLACK_ARGS} 2>&1)" ||
     black_exit_val="$?"
 
-  # Intput black formatter output to reviewdog
+  # Input black formatter output to reviewdog
   # shellcheck disable=SC2086
   echo "${black_check_output}" | /tmp/reviewdog -f="black" \
     -name="${INPUT_TOOL_NAME}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,6 +68,7 @@ unset "black_check_file_paths[-1]"
 unset "black_check_file_paths[-1]"
 
 # append the array elements to BLACK_CHECK_FILE_PATHS in github env
+# shellcheck disable=SC2129
 echo "BLACK_CHECK_FILE_PATHS<<EOF" >>"$GITHUB_ENV"
 echo "${black_check_file_paths[@]}" >>"$GITHUB_ENV"
 echo "EOF" >>"$GITHUB_ENV"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/instal
 
 if [[ "$(which black)" == "" ]]; then
   echo "[action-black] Installing black package..."
-  python -m pip install --upgrade black
+  python -m pip install --upgrade black[jupyter]
 fi
 
 # Run black with reviewdog
@@ -54,7 +54,7 @@ else
 fi
 
 # Throw error if an error occurred and fail_on_error is true
-if [[ "${INPUT_FAIL_ON_ERROR}" = 'true' && ("${black_exit_val}" -ne '0' || \
+if [[ "${INPUT_FAIL_ON_ERROR}" = 'true' && ("${black_exit_val}" -ne '0' ||
   "${reviewdog_exit_val}" -eq "1") ]]; then
   if [[ "${black_exit_val}" -eq "123" ]]; then
     # NOTE: Done since syntax errors are already handled by reviewdog (see

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,10 +25,12 @@ black_exit_val="0"
 reviewdog_exit_val="0"
 if [[ "${INPUT_REPORTER}" = 'github-pr-review' ]]; then
   echo "[action-black] Checking python code with the black formatter and reviewdog..."
+  # shellcheck disable=SC2086
   black_check_output="$(black --diff --quiet --check . ${INPUT_BLACK_ARGS})" ||
     black_exit_val="$?"
 
   # Intput black formatter output to reviewdog
+  # shellcheck disable=SC2086
   echo "${black_check_output}" | /tmp/reviewdog -f="diff" \
     -f.diff.strip=0 \
     -name="${INPUT_TOOL_NAME}" \
@@ -40,10 +42,12 @@ if [[ "${INPUT_REPORTER}" = 'github-pr-review' ]]; then
 else
 
   echo "[action-black] Checking python code with the black formatter and reviewdog..."
+  # shellcheck disable=SC2086
   black_check_output="$(black --check . ${INPUT_BLACK_ARGS} 2>&1)" ||
     black_exit_val="$?"
 
   # Intput black formatter output to reviewdog
+  # shellcheck disable=SC2086
   echo "${black_check_output}" | /tmp/reviewdog -f="black" \
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,6 +57,21 @@ else
     ${INPUT_REVIEWDOG_FLAGS} || reviewdog_exit_val="$?"
 fi
 
+# Output the checked file paths that would be formatted
+black_check_file_paths=()
+while read -r line; do
+  black_check_file_paths+=("$line")
+done <<<"${black_check_output//"would reformat "/}"
+
+# remove last two lines of black output, since they are irrelevant
+unset "black_check_file_paths[-1]"
+unset "black_check_file_paths[-1]"
+
+# append the array elements to BLACK_CHECK_FILE_PATHS in github env
+echo "BLACK_CHECK_FILE_PATHS<<EOF" >>"$GITHUB_ENV"
+echo "${black_check_file_paths[@]}" >>"$GITHUB_ENV"
+echo "EOF" >>"$GITHUB_ENV"
+
 # Throw error if an error occurred and fail_on_error is true
 if [[ "${INPUT_FAIL_ON_ERROR}" = 'true' && ("${black_exit_val}" -ne '0' ||
   "${reviewdog_exit_val}" -eq "1") ]]; then

--- a/testdata/hello.ipynb
+++ b/testdata/hello.ipynb
@@ -1,0 +1,22 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This file doesn't need formatting, so Black should skip it\n",
+    "print(\"hello world\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/testdata/hello.py
+++ b/testdata/hello.py
@@ -1,0 +1,2 @@
+# This file doesn't need formatting, so Black should skip it
+print("hello world")

--- a/testdata/num_guess.ipynb
+++ b/testdata/num_guess.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Small test script taken from https://wiki.python.org/moin/SimplePrograms\"\"\"\n",
+    "\n",
+    "import random\n",
+    "import sys # F401 'os' imported but unused\n",
+    "import os # F401 'os' imported but unused\n",
+    "\n",
+    "### E265 block comment should start with '# '\n",
+    "print(\"Hello from reviewdog!\")\n",
+    "print(\"Let's play a small number guessing game to test the flake8 github action.\")\n",
+    "print(\"This game is taken from https://wiki.python.org/moin/SimplePrograms.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "guesses_made = 0\n",
+    "\n",
+    "name = input(\"Hello! What is your name?\\n\")\n",
+    "\n",
+    "number = random.randint(1, 20)\n",
+    "print(\"Well, {0}, I am thinking of a number between 1 and 20.\".format(name)) # E501 line too long (80 > 79 characters)\n",
+    "\n",
+    "while guesses_made < 6:\n",
+    "\n",
+    "    guess = int(input(\"Take a guess: \"))\n",
+    "\n",
+    "    guesses_made += 1\n",
+    "\n",
+    "    if guess < number:\n",
+    "        print(\"Your guess is too low.\")\n",
+    "\n",
+    "    if guess > number:\n",
+    "        print(\"Your guess is too high.\")\n",
+    "\n",
+    "    if guess == number:\n",
+    "        break\n",
+    "\n",
+    "if guess == number:\n",
+    "    print(\n",
+    "        \"Good job, {0}! You guessed my number in {1} guesses!\".format(\n",
+    "            name, guesses_made\n",
+    "        )\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Nope. The number I was thinking of was {0}\".format(number))\n",
+    "\n",
+    "import itertools # E402 module level import not at top of file"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/testdata/subfolder/queen_problem.ipynb
+++ b/testdata/subfolder/queen_problem.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Small test script taken from https://wiki.python.org/moin/SimplePrograms\"\"\"\n",
+    "\n",
+    "import pwd # F401 'os' imported but unused\n",
+    "import grp # F401 'os' imported but unused\n",
+    "\n",
+    "BOARD_SIZE = 8\n",
+    "\n",
+    "### E265 block comment should start with '# '\n",
+    "print(\"Hello from reviewdog!\")\n",
+    "print(\"Let's play a small queen problem game to test the flake8 github action.\")\n",
+    "print(\"This game is taken from https://wiki.python.org/moin/SimplePrograms.\")\n",
+    "\n",
+    "class BailOut(Exception):\n",
+    "    pass\n",
+    "\n",
+    "def validate(queens):\n",
+    "    left = right = col = queens[-1] # E501 line too long (80 > 79 characters). Long description text\n",
+    "    for r in reversed(queens[:-1]):\n",
+    "        left, right = left-1, right+1\n",
+    "        if r in (left, col, right):\n",
+    "            raise BailOut\n",
+    "\n",
+    "def add_queen(queens):\n",
+    "    for i in range(BOARD_SIZE):\n",
+    "        test_queens = queens + [i]\n",
+    "        try:\n",
+    "            validate(test_queens)\n",
+    "            if len(test_queens) == BOARD_SIZE:\n",
+    "                return test_queens\n",
+    "            else:\n",
+    "                return add_queen(test_queens)\n",
+    "        except BailOut:\n",
+    "            pass\n",
+    "    raise BailOut"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "queens = add_queen([])\n",
+    "print (queens)\n",
+    "print (\"\\n\".join(\". \"*q + \"Q \" + \". \"*(BOARD_SIZE-q-1) for q in queens))\n",
+    "\n",
+    "import dis # E402 module level import not at top of file"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Since https://github.com/psf/black/pull/2357 was merged, `black` supports linting Jupyter notebook files (`.ipynb`).
This PR therefore aims to extend the action to also annotate Jupyter notebook files.

I'm not sure how this will play with Github's displaying of Jupyter notebook code, or whether the output format from black for Jupyter is different from normal python file output, so this may need more testing/adaptation.

P.S. I debated adding an extra `with` arg for this, but then figured it's easier to just use the existing `black_args`  , if you wish to exclude/disable `.ipynb` checks, but maybe a README remark on this is useful?

Input/opinions/edits welcome.