### PR TITLE
Only check changed_files in testdata/

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           workdir: ./testdata/
       - name: Check if code is left untouched (not formatted)
         run: |
-          changed_files=$(git status --porcelain | wc -l)
+          changed_files=$(git diff --name-only -- testdata/ | wc -l)
           if [[ ${changed_files} -eq 0 ]]; then
             echo "No changes detected!"
           else


### PR DESCRIPTION
I ran into some issues regarding the `changed_files` check in [`test.yml`](https://github.com/reviewdog/action-black/blob/2de44fd3bd4d9140644f86929def6dbefaa46115/.github/workflows/test.yml#L21) whilst trying to use the [`act`](https://github.com/nektos/act) tool for local actions runs/tests.

This small tweak, using `git diff` and specifying only the `testdata` dir seems to fix the issue.

`act` output on master:
```
master  v3.0.0                                                                                                                                                                                                                                                                                                         10482  19:43 
╰─ act -W .github/workflows/test.yml
[Test/runner / black-format (github-check)    ] 🚀  Start image=ghcr.io/catthehacker/ubuntu:full-20.04
[Test/runner / black-format (github-check)    ]   🐳  docker pull image=ghcr.io/catthehacker/ubuntu:full-20.04 platform= username= forcePull=false
[Test/runner / black-format (github-check)    ]   🐳  docker create image=ghcr.io/catthehacker/ubuntu:full-20.04 platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Test/runner / black-format (github-check)    ]   🐳  docker run image=ghcr.io/catthehacker/ubuntu:full-20.04 platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Test/runner / black-format (github-check)    ]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[Test/runner / black-format (github-check)    ]   🐳  docker cp src=/home/marvin/git/github/chadsr/action-black/. dst=/home/marvin/git/github/chadsr/action-black
[Test/runner / black-format (github-check)    ]   🐳  docker exec cmd=[mkdir -p /home/marvin/git/github/chadsr/action-black] user= workdir=
[Test/runner / black-format (github-check)    ] ⭐  Run actions/checkout@v2
[Test/runner / black-format (github-check)    ]   ✅  Success - actions/checkout@v2
[Test/runner / black-format (github-check)    ] ⭐  Run ./
[Test/runner / black-format (github-check)    ]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/marvin/git/github/chadsr/action-black/workflow/composite-0.sh] user= workdir=
| [action-black] Installing reviewdog...
| reviewdog/reviewdog info checking GitHub for tag 'v0.13.0'
| reviewdog/reviewdog info found version: 0.13.0 for v0.13.0/Linux/x86_64
| reviewdog/reviewdog info installed /tmp/reviewdog
| [action-black] Installing black package...
| Collecting black
|   Downloading black-21.12b0-py3-none-any.whl (156 kB)
     |████████████████████████████████| 156 kB 3.9 MB/s
| Collecting tomli<2.0.0,>=0.2.6
|   Downloading tomli-1.2.2-py3-none-any.whl (12 kB)
| Collecting pathspec<1,>=0.9.0
|   Downloading pathspec-0.9.0-py2.py3-none-any.whl (31 kB)
| Collecting platformdirs>=2
|   Downloading platformdirs-2.4.0-py3-none-any.whl (14 kB)
| Requirement already satisfied, skipping upgrade: click>=7.1.2 in /usr/local/lib/python3.8/dist-packages (from black) (8.0.1)
| Collecting typing-extensions>=3.10.0.0
|   Downloading typing_extensions-4.0.1-py3-none-any.whl (22 kB)
| Collecting mypy-extensions>=0.4.3
|   Downloading mypy_extensions-0.4.3-py2.py3-none-any.whl (4.5 kB)
| Installing collected packages: tomli, pathspec, platformdirs, typing-extensions, mypy-extensions, black
| Successfully installed black-21.12b0 mypy-extensions-0.4.3 pathspec-0.9.0 platformdirs-2.4.0 tomli-1.2.2 typing-extensions-4.0.1
| [action-black] Checking python code with the black formatter and reviewdog...
| reviewdog: environment variable $REVIEWDOG_GITHUB_API_TOKEN is not set
| [action-black] Clean up reviewdog...
[Test/runner / black-format (github-check)    ]   ✅  Success - ./
[Test/runner / black-format (github-check)    ] ⭐  Run Check if code is left untouched (not formatted)
[Test/runner / black-format (github-check)    ]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/marvin/git/github/chadsr/action-black/workflow/2] user= workdir=
| Changes detected!
[Test/runner / black-format (github-check)    ]   ❌  Failure - Check if code is left untouched (not formatted)
Error: exit with `FAILURE`: 1
```

`act` output on this branch:
```
fix/test-changes                                                                                                                                                                                                                                                                                                        10484  19:47 
╰─ act -W .github/workflows/test.yml
[Test/runner / black-format (github-check)    ] 🚀  Start image=ghcr.io/catthehacker/ubuntu:full-20.04
[Test/runner / black-format (github-check)    ]   🐳  docker pull image=ghcr.io/catthehacker/ubuntu:full-20.04 platform= username= forcePull=false
[Test/runner / black-format (github-check)    ]   🐳  docker create image=ghcr.io/catthehacker/ubuntu:full-20.04 platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Test/runner / black-format (github-check)    ]   🐳  docker run image=ghcr.io/catthehacker/ubuntu:full-20.04 platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Test/runner / black-format (github-check)    ]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[Test/runner / black-format (github-check)    ]   🐳  docker cp src=/home/marvin/git/github/chadsr/action-black/. dst=/home/marvin/git/github/chadsr/action-black
[Test/runner / black-format (github-check)    ]   🐳  docker exec cmd=[mkdir -p /home/marvin/git/github/chadsr/action-black] user= workdir=
[Test/runner / black-format (github-check)    ] ⭐  Run actions/checkout@v2
[Test/runner / black-format (github-check)    ]   ✅  Success - actions/checkout@v2
[Test/runner / black-format (github-check)    ] ⭐  Run ./
[Test/runner / black-format (github-check)    ]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/marvin/git/github/chadsr/action-black/workflow/composite-0.sh] user= workdir=
| [action-black] Installing reviewdog...
| reviewdog/reviewdog info checking GitHub for tag 'v0.13.0'
| reviewdog/reviewdog info found version: 0.13.0 for v0.13.0/Linux/x86_64
| reviewdog/reviewdog info installed /tmp/reviewdog
| [action-black] Installing black package...
| Collecting black
|   Downloading black-21.12b0-py3-none-any.whl (156 kB)
     |████████████████████████████████| 156 kB 4.0 MB/s
| Collecting platformdirs>=2
|   Downloading platformdirs-2.4.0-py3-none-any.whl (14 kB)
| Collecting tomli<2.0.0,>=0.2.6
|   Downloading tomli-1.2.2-py3-none-any.whl (12 kB)
| Requirement already satisfied, skipping upgrade: click>=7.1.2 in /usr/local/lib/python3.8/dist-packages (from black) (8.0.1)
| Collecting pathspec<1,>=0.9.0
|   Downloading pathspec-0.9.0-py2.py3-none-any.whl (31 kB)
| Collecting mypy-extensions>=0.4.3
|   Downloading mypy_extensions-0.4.3-py2.py3-none-any.whl (4.5 kB)
| Collecting typing-extensions>=3.10.0.0
|   Downloading typing_extensions-4.0.1-py3-none-any.whl (22 kB)
| Installing collected packages: platformdirs, tomli, pathspec, mypy-extensions, typing-extensions, black
| Successfully installed black-21.12b0 mypy-extensions-0.4.3 pathspec-0.9.0 platformdirs-2.4.0 tomli-1.2.2 typing-extensions-4.0.1
| [action-black] Checking python code with the black formatter and reviewdog...
| reviewdog: environment variable $REVIEWDOG_GITHUB_API_TOKEN is not set
| [action-black] Clean up reviewdog...
[Test/runner / black-format (github-check)    ]   ✅  Success - ./
[Test/runner / black-format (github-check)    ] ⭐  Run Check if code is left untouched (not formatted)
[Test/runner / black-format (github-check)    ]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/marvin/git/github/chadsr/action-black/workflow/2] user= workdir=
| No changes detected!
[Test/runner / black-format (github-check)    ]   ✅  Success - Check if code is left untouched (not formatted)
```