### PR TITLE
ci: replace 'create-release action' with gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,18 +37,13 @@ jobs:
           if_true: ${{ github.ref }}
           if_false: ${{ steps.bumpr.outputs.next_version }}
 
-      # Create release.
-      - uses: actions/create-release@v1
-        if: "steps.tag.outputs.value != ''"
+      # Create release
+      - if: "steps.tag.outputs.value != ''"
+        run: |
+          gh release create ${{ steps.tag.outputs.value }} -t Release ${{ steps.tag.outputs.value }} --notes "${{ steps.bumpr.outputs.message }}"
         env:
           # This token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.tag.outputs.value }}
-          release_name: Release ${{ steps.tag.outputs.value }}
-          body: ${{ steps.bumpr.outputs.message }}
-          draft: false
-          prerelease: false
 
   release-check:
     if: github.event.action == 'labeled'


### PR DESCRIPTION
This commit replaces the [create-releaseaction](https://github.com/actions/create-release) since this action was depricated.
