### PR TITLE
fix: correct incorrect link URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ Contains all the files that would be changed by black.
 
 ## Format your code
 
-This action is meant to annotate any possible changes that would need to be made to make your code adhere to the [black formatting guidelines](github.com/psf/black). It does not apply these changes to your codebase. If you also want to apply the changes to your repository, you can use the [reviewdog/action-suggester](https://github.com/reviewdog/action-suggester). You can find examples of how this is done can be found in [rickstaa/action-black](https://github.com/rickstaa/action-black/)
+This action is meant to annotate any possible changes that would need to be made to make your code adhere to the [black formatting guidelines](https://github.com/psf/black). It does not apply these changes to your codebase. If you also want to apply the changes to your repository, you can use the [reviewdog/action-suggester](https://github.com/reviewdog/action-suggester). You can find examples of how this is done can be found in [rickstaa/action-black](https://github.com/rickstaa/action-black/)


### PR DESCRIPTION
### Overview
The link URL in the README.md file was incorrect. It currently points to a relative path, which results in the link being interpreted as `https://github.com/reviewdog/action-black/blob/master/github.com/psf/black` when viewed in HTML.

### Changes
- Corrected the link to point to `https://github.com/psf/black` instead of `github.com/psf/black`.

### Issue
This issue causes the link to lead to an incorrect location, making it hard for users to access the correct resource.

Please review the change, and let me know if further adjustments are needed.
