### PR TITLE
increase compatibility by not hard-coding bash path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # <!--alex disable black-->
 
 set -eu # Increase bash strictness.


### PR DESCRIPTION
On some linux distributions, `/bin/bash` does not exist.